### PR TITLE
fix server.sh setup for centos

### DIFF
--- a/setup/server/server.sh
+++ b/setup/server/server.sh
@@ -516,6 +516,7 @@ ubuntu_install_php(){
 centos_install_php(){
     echoG 'Install PHP & Packages'  
     /usr/bin/yum install -y http://rpms.remirepo.net/enterprise/remi-release-7.rpm >/dev/null 2>&1
+    /usr/bin/yum install -y yum-utils >/dev/null 2>&1
     /usr/bin/yum-config-manager --enable remi-php72 >/dev/null 2>&1
     /usr/bin/yum install -y php-common php-pdo php-gd php-mbstring php-mysqlnd php-litespeed php-opcache php-pecl-zip php-tidy php-gmp \
                    php-bcmath php-enchant php-cli php-json php-xml php php-fpm php-recode php-soap php-xmlrpc php-sodium \

--- a/setup/server/server.sh
+++ b/setup/server/server.sh
@@ -252,8 +252,16 @@ centos_install_pkg(){
     if [ ! -e /bin/wget ]; then 
         silent yum install epel-release -y
         silent yum update -y
-        silent yum install curl wget -y
+        silent yum install curl yum-utils wget -y
+    fi
+    if [[ -z "$(rpm -qa epel-release)" ]]; then
+        silent yum install epel-release -y
+    fi
+    if [ ! -e /usr/bin/yum-config-manager ]; then 
         silent yum install yum-utils -y
+    fi
+    if [ ! -e /usr/bin/curl ]; then 
+        silent yum install curl -y
     fi
 
 ### Install postfix


### PR DESCRIPTION
missing yum-utils package so yum-config-manager was missing and unable to enable remi-php72 repo to install php leading to cascading failures to install and run wp-cli to setup wordpress site under centos OS